### PR TITLE
Fix ping

### DIFF
--- a/src/nebula/Connection.ts
+++ b/src/nebula/Connection.ts
@@ -143,10 +143,10 @@ export default class Connection extends EventEmitter {
         const timer = setTimeout(() => { resolve(false) }, timeout)
         this
           .client
-          .execute(0, 'YIELD 1')
-          .then(() => {
+          .execute(this.sessionId, 'YIELD 1')
+          .then(response => {
             clearTimeout(timer)
-            resolve(true)
+            resolve(response.error_code === 0)
           })
           .catch(() => {
             clearTimeout(timer)


### PR DESCRIPTION
I was getting invalid session errors in the driver during periods of zero-activity. Looking into the driver, the ping function does not use the correct session id. Now it works and no longer throws error -1002. Also improved error reporting if something goes wrong during ping.