### PR TITLE
Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ Not implemented data type for auto parser
 
 | Data Type | property name in nebula response |
 | --------- | -------------------------------- |
-| NMap      | mVal                             |
-| NSet      | uVal                             |
 | DataSet   | gVal                             |
+| Geography | ggVal                            |
+| Duration  | duVal                            |
 
 ## Released Versions in npmjs.com
 

--- a/src/nebula/parser/map.ts
+++ b/src/nebula/parser/map.ts
@@ -5,5 +5,5 @@
  */
 
 export default (obj: any, propName: string): any => {
-  return obj[propName]
+  return obj[propName].kvs || {}
 }

--- a/src/nebula/parser/set.ts
+++ b/src/nebula/parser/set.ts
@@ -5,5 +5,5 @@
  */
 
 export default (obj: any, propName: string): any => {
-  return obj[propName]
+  return obj[propName].values || []
 }

--- a/src/nebula/parser/traverse.ts
+++ b/src/nebula/parser/traverse.ts
@@ -103,7 +103,7 @@ const traverse = (obj: any): any => {
 
     _.forEach(rows, row => {
       _.forEach(columns, (c, i) => {
-        entity[c] = _.concat(entity[c], row.values[i])
+        entity[c].push(row.values[i])
       })
     })
 

--- a/src/nebula/parser/utils.ts
+++ b/src/nebula/parser/utils.ts
@@ -6,7 +6,7 @@
 import { NebulaValue } from '../types'
 import _ from 'lodash'
 
-const NubulaValueTypeNames = [
+const NebulaValueTypeNames = [
   'nVal',
   'bVal',
   'iVal',
@@ -15,8 +15,6 @@ const NubulaValueTypeNames = [
   'dVal',
   'tVal',
   'dtVal',
-  'mVal',
-  'uVal',
   'gVal'
 ]
 
@@ -30,7 +28,7 @@ const isNebulaValue = (obj: any): boolean => {
 }
 
 const isNebulaValueTypeName = (propName: string): boolean => {
-  return _.includes(NubulaValueTypeNames, propName)
+  return _.includes(NebulaValueTypeNames, propName)
 }
 
 const isNebulaNListTypeName = (propName: string): boolean => {

--- a/tests/nebula.test.ts
+++ b/tests/nebula.test.ts
@@ -22,7 +22,9 @@ const commands = {
   cmd3: 'go from "c001" over employee yield properties($^) as a, properties($$) as b, properties(edge) as p',
   cmd4: 'find noloop path with prop from "p001" to "p002" over * yield path as p',
   cmd5: 'RETURN list[1, 2, 3] AS a',
-  cmd6: 'UNWIND list[list[1, 2, 3], list[2, 3, 4]] as a RETURN a'
+  cmd6: 'UNWIND list[list[1, 2, 3], list[2, 3, 4]] as a RETURN a',
+  cmd7: 'RETURN set{1, 2, 3} AS a',
+  cmd8: 'RETURN map{a: LIST[1,2], b: SET{1,2,1}, c: "hee"} as a'
 }
 
 describe('nebula', () => {
@@ -84,6 +86,30 @@ describe('nebula', () => {
     const response1 = await client.execute(commands.cmd6)
 
     expect(response1.data?.a).deep.equal([[1, 2, 3], [2, 3, 4]])
+
+    await client.close()
+  })
+
+  it('test-case-7-set', async () => {
+    const client = createClient(nebulaServer)
+
+    const response1 = await client.execute(commands.cmd7)
+
+    expect(response1.data?.a?.length).to.equal(1)
+    expect(response1.data?.a[0]?.length).to.equal(3)
+
+    await client.close()
+  })
+
+  it('test-case-8-map', async () => {
+    const client = createClient(nebulaServer)
+
+    const response1 = await client.execute(commands.cmd8)
+
+    expect(response1.data?.a?.length).to.equal(1)
+    expect(response1.data?.a[0]?.a).to.deep.equal([1, 2])
+    expect(response1.data?.a[0]?.b?.length).to.equal(2)
+    expect(response1.data?.a[0]?.c).to.equal('hee')
 
     await client.close()
   })

--- a/tests/nebula.test.ts
+++ b/tests/nebula.test.ts
@@ -20,7 +20,9 @@ const commands = {
   cmd1: 'get subgraph with prop 2 steps from "p001" yield vertices as nodes, edges as relationships',
   cmd2: 'fetch prop on company "c001" yield properties(vertex) as node',
   cmd3: 'go from "c001" over employee yield properties($^) as a, properties($$) as b, properties(edge) as p',
-  cmd4: 'find noloop path with prop from "p001" to "p002" over * yield path as p'
+  cmd4: 'find noloop path with prop from "p001" to "p002" over * yield path as p',
+  cmd5: 'RETURN list[1, 2, 3] AS a',
+  cmd6: 'UNWIND list[list[1, 2, 3], list[2, 3, 4]] as a RETURN a'
 }
 
 describe('nebula', () => {
@@ -66,9 +68,27 @@ describe('nebula', () => {
     await client.close()
   })
 
+  it('test-case-5-list', async () => {
+    const client = createClient(nebulaServer)
+
+    const response1 = await client.execute(commands.cmd5)
+
+    expect(response1.data?.a).deep.equal([[1, 2, 3]])
+
+    await client.close()
+  })
+
+  it('test-case-6-list', async () => {
+    const client = createClient(nebulaServer)
+
+    const response1 = await client.execute(commands.cmd6)
+
+    expect(response1.data?.a).deep.equal([[1, 2, 3], [2, 3, 4]])
+
+    await client.close()
+  })
+
   after(async () => {
     process.exit()
   })
 })
-
-


### PR DESCRIPTION
1. [implement NMap and NSet data type for parser](https://github.com/nebula-contrib/nebula-node/commit/54cdc4662019a3c13cd8b2ff792c8717b62020bc)
2. [use array push instead array concat when traverse each rows](https://github.com/nebula-contrib/nebula-node/commit/71406524cd69c7d9cfcd746f662af5b720734178)
  query`RETURN list[1, 2, 3] AS a`(table cell is an array like object)
  when using array concat,  will return`[1, 2, 3]` which is wrong
  when using array push, will return `[[1, 2, 3]]` which is right
